### PR TITLE
Fixed formatting in printf

### DIFF
--- a/memwatch.c
+++ b/memwatch.c
@@ -63,7 +63,7 @@ int CheckUsage(const char *filename)
       Percentage = (float)(((float)TotalUsage/1024)/(float)TotalRam)*100;
 
 
-      printf("%10lukB %10lukB %10.3f%\n", TotalRam, TotalUsage/1024, Percentage);
+      printf("%10lukB %10lukB %10.3f%%\n", TotalRam, TotalUsage/1024, Percentage);
 
       fclose(FP);
 


### PR DESCRIPTION
The current implementation will give the following warning:

memwatch.c: In function ‘CheckUsage’:
memwatch.c:66:7: warning: unknown conversion type character 0xa in format [-Wformat]

Please pull the change to fix it.

Regards,
Aniruddha.
